### PR TITLE
Fix PollInterval env var bug and add config test

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ func GetConfig() *Config {
 
 	if envPollInterval := os.Getenv("POLL_INTERVAL"); envPollInterval != "" {
 		if envPollInterval, err := strconv.Atoi(envPollInterval); err == nil {
-			cfg.ReportInterval = envPollInterval
+			cfg.PollInterval = envPollInterval
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestGetConfigEnvPollInterval(t *testing.T) {
+	t.Setenv("POLL_INTERVAL", "5")
+	t.Setenv("REPORT_INTERVAL", "9")
+
+	flag.CommandLine = flag.NewFlagSet("test", flag.ExitOnError)
+	cfg := GetConfig()
+
+	if cfg.PollInterval != 5 {
+		t.Errorf("expected PollInterval=5, got %d", cfg.PollInterval)
+	}
+	if cfg.ReportInterval != 9 {
+		t.Errorf("expected ReportInterval=9, got %d", cfg.ReportInterval)
+	}
+}


### PR DESCRIPTION
## Summary
- fix incorrect assignment when reading POLL_INTERVAL env variable
- add unit test to verify env variables are parsed correctly

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d73bdd960832db899a44a9f0d464d